### PR TITLE
Extend Oracle Support (3D geometries)

### DIFF
--- a/src/main/java/liquibase/ext/spatial/sqlgenerator/OracleSpatialUtils.java
+++ b/src/main/java/liquibase/ext/spatial/sqlgenerator/OracleSpatialUtils.java
@@ -1,79 +1,122 @@
 package liquibase.ext.spatial.sqlgenerator;
 
+import java.io.IOException;
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import liquibase.database.Database;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.ext.spatial.sqlgenerator.WktConversionUtils.EWKTInfo;
 import liquibase.util.StringUtils;
 
 /**
  * <code>OracleSpatialUtils</code> provides utility methods for Oracle Spatial.
  */
 public class OracleSpatialUtils {
-   /** The Oracle function that converts an EPSG SRID to the corresponding Oracle SRID. */
+
+   /**
+    * The Oracle function that converts an EPSG SRID to the corresponding Oracle
+    * SRID.
+    */
    public static final String EPSG_TO_ORACLE_FUNCTION = "SDO_CS.MAP_EPSG_SRID_TO_ORACLE";
 
    /** The mapping of EPSG SRID to Oracle SRID. */
    private final static Map<String, String> EPSG_TO_ORACLE_MAP = Collections
          .synchronizedMap(new HashMap<String, String>());
 
+   /** Stores if Oracle SRID is projecter or not. */
+   private final static Map<String, String> ORACLE_SRID_KIND = Collections
+         .synchronizedMap(new HashMap<String, String>());
+
+   public static final String ORACLE_SR_KIND_PROJECTED = "PROJECTED";
+
+   public static final BigDecimal DECIMAL_MULTIPLIER = new BigDecimal(10000000);
+
    /** Hide the default constructor. */
    private OracleSpatialUtils() {
    }
 
    /**
-    * Converts the given Well-Known Text string to one that will work in Oracle. If the string is
-    * greater than 4000 characters, the string is broken into pieces where each piece is converted
-    * to a CLOB. The CLOB handling assumes that the result will be wrapped in single quotes so it
-    * wraps the result in "<code>' || TO_CLOB(...) || '</code>".
+    * Converts the given Well-Known Text string to one that will work in Oracle.
+    * If the string is greater than 4000 characters, the string is broken into
+    * pieces where each piece is converted to a CLOB. The CLOB handling assumes
+    * that the result will be wrapped in single quotes so it wraps the result in
+    * "<code>' || TO_CLOB(...) || '</code>".
     * 
-    * @param wkt
-    *           the Well-Known Text string to convert.
-    * @return the original WKT or a <code>TO_CLOB</code> concatenation of the WKT.
+    * @param wkt the Well-Known Text string to convert.
+    * @return the original WKT or a <code>TO_CLOB</code> concatenation of the
+    *         WKT.
     */
    public static String getOracleWkt(final String wkt) {
-      final String oracleWkt;
+      final StringBuilder oracleWkt = new StringBuilder();
       // Strings longer than 4000 characters need to be converted to CLOBs.
-      if (wkt.length() > 4000) {
-         int index = 4000;
-         final StringBuilder clobs = new StringBuilder("' || TO_CLOB('").append(
-               wkt.substring(0, index)).append("')");
-         while (index < wkt.length()) {
-            final int endIndex = Math.min(index + 4000, wkt.length());
-            clobs.append(" || TO_CLOB('").append(wkt.substring(index, endIndex)).append("')");
+      splitStringIntoClobsExpression(wkt, oracleWkt, true, null);
+      return oracleWkt.toString();
+   }
+
+   /**
+    * If the string is greater than 4000 characters, the string is broken into
+    * pieces where each piece is converted to a CLOB. If
+    * <code>insideString</code> The CLOB handling assumes that the result will
+    * be wrapped in single quotes so it wraps the result in "
+    * <code>' || TO_CLOB(...) || '</code>".
+    * 
+    * @param source
+    * @param builder
+    * @param insideString
+    * @param limit (optional default 4000)
+    * @return
+    */
+   public static void splitStringIntoClobsExpression(final String source,
+         StringBuilder builder, boolean insideString, Integer limit) {
+      final int curLimit = limit == null ? 4000 : limit;
+      if (source.length() > curLimit) {
+         int index = curLimit;
+         if (insideString) {
+            builder.append("' || ");
+         }
+         builder.append("TO_CLOB('").append(source.substring(0, index))
+               .append("')");
+         while (index < source.length()) {
+            final int endIndex = Math.min(index + curLimit, source.length());
+            builder.append(" || TO_CLOB('")
+                  .append(source.substring(index, endIndex)).append("')");
             index = endIndex;
          }
-         clobs.append(" || '");
-         oracleWkt = clobs.toString();
-      } else {
-         oracleWkt = wkt;
+         if (insideString) {
+            builder.append(" || '");
+         }
       }
-      return oracleWkt;
+      else {
+         builder.append(source);
+      }
    }
 
    /**
     * Converts the given EPSG SRID to the corresponding Oracle SRID.
     * 
-    * @param srid
-    *           the EPSG SRID.
-    * @param database
-    *           the database instance.
+    * @param srid the EPSG SRID.
+    * @param database the database instance.
     * @return the corresponding Oracle SRID.
     */
    public static String getOracleSrid(final String srid, final Database database) {
       final String oracleSrid;
       if (StringUtils.trimToNull(srid) == null) {
          oracleSrid = null;
-      } else if (EPSG_TO_ORACLE_MAP.containsKey(srid)) {
+      }
+      else if (EPSG_TO_ORACLE_MAP.containsKey(srid)) {
          oracleSrid = EPSG_TO_ORACLE_MAP.get(srid);
-      } else {
+      }
+      else {
          oracleSrid = loadOracleSrid(srid, database);
          EPSG_TO_ORACLE_MAP.put(srid, oracleSrid);
       }
@@ -81,34 +124,402 @@ public class OracleSpatialUtils {
    }
 
    /**
-    * Queries to the database to convert the given EPSG SRID to the corresponding Oracle SRID.
+    * @see #getOracleSRIDExpression(String)
+    */
+   public static String getOracleSRIDExpression(Integer epsgSrid) {
+      return getOracleSRIDExpression(String.valueOf(epsgSrid));
+   }
+
+   /**
+    * Generate Oracle SQL Expression to get Oracle-SRID based on EPSG-SRID
     * 
-    * @param srid
-    *           the EPSG SRID.
-    * @param database
-    *           the database instance.
+    * @param epsgSrid
+    * @return
+    */
+   public static String getOracleSRIDExpression(String epsgSrid) {
+      // XXX For EPSG25830 SDO_CS.MAP_EPSG_SRID_TO_ORACLE return null
+      // but on SDO_COORD_REF_SYSTEM.srid = 25830 matches correctly.
+      // So, use COALESCE + Subquery expression to get it:
+
+      // COALESCE( SDO_CS.MAP_EPSG_SRID_TO_ORACLE(25830),
+      // (SELECT srid SDO_COORD_REF_SYSTEM where srid = 25830))
+
+      return String
+            .format(
+                  "COALESCE( %s(%s), (SELECT srid from SDO_COORD_REF_SYSTEM where srid = %s))",
+                  OracleSpatialUtils.EPSG_TO_ORACLE_FUNCTION, epsgSrid,
+                  epsgSrid);
+   }
+
+   /**
+    * Queries to the database to convert the given EPSG SRID to the
+    * corresponding Oracle SRID.
+    * 
+    * @param srid the EPSG SRID.
+    * @param database the database instance.
     * @return the corresponding Oracle SRID.
     */
-   public static String loadOracleSrid(final String srid, final Database database) {
-      final String oracleSrid;
-      final JdbcConnection jdbcConnection = (JdbcConnection) database.getConnection();
+   public static String loadOracleSrid(final String srid,
+         final Database database) {
+      String oracleSrid;
+      try {
+         oracleSrid = getStringFromQuery("SELECT "
+               + getOracleSRIDExpression(srid) + " FROM dual", database);
+
+         if (oracleSrid == null) {
+            // for 25830 SDO_CS.MAP_EPSG_SRID_TO_ORACLE returns null when
+            // 25830 is registered on SDO_COORD_REF_SYSTEM (???).
+            // Try to find in using SDO_COORD_REF_SYSTEM.srid field
+            oracleSrid = getStringFromQuery(
+                  "SELECT srid from SDO_COORD_REF_SYSTEM FROM dual where srid ="
+                        .concat(srid),
+                  database);
+         }
+      }
+      catch (final SQLException e) {
+         throw new UnexpectedLiquibaseException(
+               "Failed to find the Oracle SRID for EPSG:" + srid, e);
+      }
+      return oracleSrid;
+   }
+
+   /**
+    * Execute <code>sql</code> query and gets the first result column (as
+    * string)
+    * 
+    * @param sql of query
+    * @param database
+    * @return first query result column
+    * @throws SQLException
+    */
+   private static String getStringFromQuery(final String sql,
+         final Database database) throws SQLException {
+
+      final String result;
+      final JdbcConnection jdbcConnection = (JdbcConnection) database
+            .getConnection();
       final Connection connection = jdbcConnection.getUnderlyingConnection();
       Statement statement = null;
       try {
          statement = connection.createStatement();
-         final ResultSet resultSet = statement.executeQuery("SELECT " + EPSG_TO_ORACLE_FUNCTION
-               + "(" + srid + ") FROM dual");
+         final ResultSet resultSet = statement.executeQuery(sql);
          resultSet.next();
-         oracleSrid = resultSet.getString(1);
-      } catch (final SQLException e) {
-         throw new UnexpectedLiquibaseException("Failed to find the Oracle SRID for EPSG:" + srid,
-               e);
-      } finally {
+         result = resultSet.getString(1);
+      }
+      finally {
          try {
             statement.close();
-         } catch (final SQLException ignore) {
+         }
+         catch (final SQLException ignore) {
          }
       }
-      return oracleSrid;
+      return result;
+   }
+
+   /**
+    * Informs if a EPSG SRID is projected or not (based on Oracle SYS_REF table
+    * info)
+    * 
+    * @param epsgSrid
+    * @param database
+    * @return true if SRID is projected
+    */
+   public static boolean isSRIDProjected(String epsgSrid, Database database) {
+      final String oracleSrid = getOracleSrid(epsgSrid, database);
+      return isOracleSRIDProjected(oracleSrid, database);
+   }
+
+   /**
+    * Informs if a EPSG SRID is projected or not (based on Oracle SYS_REF table
+    * info)
+    * 
+    * @param epsgSrid
+    * @param database
+    * @return true if SRID is projected
+    */
+   public static boolean isOracleSRIDProjected(String oraSrid, Database database) {
+      String kind = getOracleSRIDKind(oraSrid, database);
+      return ORACLE_SR_KIND_PROJECTED.equalsIgnoreCase(kind);
+
+   }
+
+   /**
+    * Gets COORD_REF_SYS_KIND of a Oracle SRID
+    * 
+    * @param oraSrid
+    * @param database
+    * @return COORD_REF_SYS_KIND of the Oracle SRID
+    */
+   public static String getOracleSRIDKind(String oraSrid, Database database) {
+      String kind = ORACLE_SRID_KIND.get(oraSrid);
+      if (kind == null) {
+         try {
+            kind = getStringFromQuery(
+                  "Select COORD_REF_SYS_KIND from SDO_COORD_REF_SYSTEM where srid = "
+                        .concat(oraSrid),
+                  database);
+            ORACLE_SRID_KIND.put(oraSrid, kind);
+         }
+         catch (final SQLException e) {
+            throw new UnexpectedLiquibaseException(
+                  "Failed to indentify if the Oracle SRID is projected:"
+                        + oraSrid, e);
+         }
+      }
+      return kind;
+   }
+
+   /**
+    * Generates SDO_GEOMETRY constructor (native geometry constructor)
+    * expression for a WKT. <br/>
+    * This generates a expression using constructor call:
+    * <code>SDO_GEOMETRY(SDO_GTYPE, SDO_SRID , SDO_POINT, SDO_ELEM_INFO,
+    * SDO_ORDINATES)</code> which defines a Oracle Geometry. <br/>
+    * Example, for the WKT string: <br/>
+    * <code>POLYGON(3 3, 6 3, 6 5, 4 5, 3 3)</code> <br/>
+    * This method generates: <br/>
+    * <code>SDO_GEOMETRY(2003,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1003,1),
+    * SDO_ORDINATE_ARRAY(3,3,6,3,6,5,4,5,3,3))</code>
+    * 
+    * 
+    * @param wktInfo
+    * @param srid
+    * @param database
+    * @return SDO_GEOMETRY constructor-call string
+    */
+   public static String getNativeOracleConstructor(final EWKTInfo wktInfo,
+         final String srid, final Database database) {
+      return getNativeOracleConstructor(wktInfo, srid, null, database);
+   }
+
+   /**
+    * Generates SDO_GEOMETRY constructor (native geometry constructor)
+    * expression for a WKT string. <br/>
+    * This method generates a expression using constructor call:
+    * <code>SDO_GEOMETRY(SDO_GTYPE, SDO_SRID , SDO_POINT, SDO_ELEM_INFO,
+    * SDO_ORDINATES)</code> which defines a Oracle Geometry. <br/>
+    * Example, for the WKT string: <br/>
+    * <code>POLYGON(3 3, 6 3, 6 5, 4 5, 3 3)</code> <br/>
+    * This method generates: <br/>
+    * <code>SDO_GEOMETRY(2003,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1003,1),
+    * SDO_ORDINATE_ARRAY(3,3,6,3,6,5,4,5,3,3))</code> <br/>
+    * <code>limit</code> defines the maximum number of parameters allowed on
+    * array creation. If arrays are bigger, will be generate expression to avoid
+    * it (this is related to <code>ORA-00939</code>. Uses expressions based
+    * on xml-structure oracle support to load the array as a string.
+    * 
+    * 
+    * @param wktInfo
+    * @param srid
+    * @param limit (optional default 900) max array limit
+    * @param database
+    * @return SDO_GEOMETRY constructor-call string
+    */
+   public static String getNativeOracleConstructor(final EWKTInfo wktInfo,
+         final String srid, Integer arrayLimit, final Database database) {
+
+      // Prepare common data
+      String sdoGtype = getSDO_GTYPE(wktInfo);
+      String oracleSRID = "NULL";
+      if (srid != null) {
+         String tmpOracleSRID = getOracleSrid(srid, database);
+         if (tmpOracleSRID != null && !tmpOracleSRID.isEmpty()) {
+            oracleSRID = tmpOracleSRID;
+         }
+      }
+      else if (wktInfo.getSrid() != null) {
+         String tmpOracleSRID = getOracleSrid(wktInfo.getSrid(), database);
+         if (tmpOracleSRID != null && !tmpOracleSRID.isEmpty()) {
+            oracleSRID = tmpOracleSRID;
+         }
+      }
+
+      // Function call
+      StringBuilder sbuilder = new StringBuilder("SDO_GEOMETRY(");
+
+      // Append SDO_GTYPE
+      sbuilder.append(sdoGtype).append(',');
+
+      // Append SDO_SRID
+      sbuilder.append(oracleSRID).append(',');
+
+      // Append SDO_POINT (not used)
+      sbuilder.append("NULL,");
+
+      // Prepare SDO_ELEMENT_INFO_ARRAY
+      List<String> elementInfo = new ArrayList<String>();
+
+      // Prepare SDO_ORDINATES_ARRAY
+      List<String> ordinates = new ArrayList<String>();
+
+      // Process WKT to generate SDO_ELEM_INFO_ARRAY and SDO_ORDINATES_ARRAY
+      OracleWktCoordiantesProcessor processor = new OracleWktCoordiantesProcessor();
+      try {
+         processor.process(wktInfo.getWktWithoutSRID(), elementInfo, ordinates);
+      }
+      catch (IOException e) {
+         throw new IllegalArgumentException("Invalid WKT", e);
+      }
+
+      // Append SDO_ELEMENT_INFO and prepare coordinates
+      writeSdoArray(elementInfo,"SDO_ELEM_INFO_ARRAY", arrayLimit, sbuilder);
+      sbuilder.append(",");
+      // sbuilder.append("SDO_ELEM_INFO_ARRAY(");
+      // writeCommaSeparatedList(elementInfo, sbuilder);
+      // sbuilder.append("),");
+
+      // Append SDO_ORDINATES
+      writeSdoArray(ordinates,"SDO_ORDINATE_ARRAY", arrayLimit, sbuilder);
+      // sbuilder.append("SDO_ORDINATE_ARRAY(");
+      // writeCommaSeparatedList(ordinates, sbuilder);
+      // sbuilder.append(')');
+
+      return sbuilder.append(')').toString();
+   }
+
+   /**
+    * Write on a {@link StringBuilder} constructor expression to generate a
+    * SDO_ELEM_INFO_ARRAY or SDO_ORDINATE_ARRAY
+    * 
+    * @param arrayItems
+    * @param type
+    * @param limit of array items to use XML-expression way
+    * @param sbuilder
+    */
+   private static void writeSdoArray(List<String> arrayItems, String type, Integer limit,
+         StringBuilder sbuilder) {
+
+      int curLimit = limit == null ? 900 : limit;
+
+      if (arrayItems.size() < curLimit) {
+         writeConstructorWithNumericArray(type, arrayItems,
+               sbuilder);
+      }
+      else {
+         /**
+          * (select cast(multiset(select to_number(x.column_value.extract('v/text()'))c from table(xmlsequence(xmltype('<r><v>1.2</v><v>2332322.3333</v></r>').extract('r/v')))x)as SDO_ELEM_INFO_ARRAY)from dual)
+          */
+         sbuilder
+               .append("(select cast(multiset(select to_number(x.column_value.extract('v/text()'))c from table(xmlsequence(xmltype('<r>");
+
+         // Avoid long string problem
+         StringBuilder tmpBuilder = new StringBuilder();
+         writeXmlList(arrayItems, "v", tmpBuilder);
+         splitStringIntoClobsExpression(tmpBuilder.toString(), sbuilder, true,
+               null);
+
+         sbuilder.append("</r>').extract('r/v')))x)as ").append(type).append(")from dual)");
+      }
+   }
+
+   /**
+    * Write on a {@link StringBuilder} constructor expression which receives
+    * an array of numeric elements.
+    * 
+    * @param contructorFunction
+    * @param arrayItems
+    * @param sbuilder
+    */
+   private static <T> void writeConstructorWithNumericArray(
+         String contructorFunction, List<T> arrayItems, StringBuilder sbuilder) {
+      sbuilder.append(contructorFunction).append("(");
+      writeCommaSeparatedList(arrayItems, sbuilder);
+      sbuilder.append(')');
+   }
+
+
+   /**
+    * Write on a {@link StringBuilder} a list of elements as a XML
+    * tag sequence
+    * 
+    * @param list
+    * @param tagName
+    * @param sbuilder
+    */
+   private static void writeXmlList(List<String> list,
+         String tagName,StringBuilder sbuilder) {
+      final String start = "<".concat(tagName).concat(">");
+      final String end = "</".concat(tagName).concat(">");
+      for (String value : list) {
+         sbuilder.append(start).append(value).append(end);
+      }
+   }
+
+   /**
+    * Write on a {@link StringBuilder} a list of elements as a comma 
+    * separated list
+    * 
+    * @param list
+    * @param sbuilder
+    */
+   private static <T> void writeCommaSeparatedList(List<T> list,
+         StringBuilder sbuilder) {
+      final int last = list.size() - 1;
+      for (int i = 0; i < last; i++) {
+         sbuilder.append(list.get(i));
+         sbuilder.append(',');
+      }
+      sbuilder.append(list.get(last));
+   }
+
+   /**
+    * Return the <code>SDO_GTYPE</code> of a geometry based on wktInfo
+    * 
+    * @param wktInfo
+    * @return
+    */
+   public static String getSDO_GTYPE(final EWKTInfo info) {
+      // Prepares number of dimensions and M coordinate position
+      int d = getDimensions(info);
+      int l = 0;
+
+      // if has M this will be the last coordinate
+      if (info.isMCoordinate()) {
+         l = d;
+      }
+
+      // Identifies the type
+      int t = 0;
+      if (info.isCollection()) {
+         t = 4;
+      }
+      else {
+         final String baseType = info.getGeometryBaseType();
+         if ("POINT".equals(baseType)) {
+            t = 1;
+         }
+         else if ("LINESTRING".equals(baseType)) {
+            t = 2;
+         }
+         else if ("POLYGON".equals(baseType)) {
+            t = 3;
+         }
+         else {
+            throw new IllegalArgumentException(
+                  "Unknow base geometry type: ".concat(baseType));
+         }
+         if (info.isMulti()) {
+            t = t + 4;
+         }
+      }
+
+      return String.format("%s%s0%s", d, l, t);
+   }
+
+   /**
+    * Get number of dimensions of a WKT definition
+    * 
+    * @param info
+    * @return
+    */
+   private static int getDimensions(EWKTInfo info) {
+      int n = 2;
+      if (info.isZCoordinate()) {
+         n++;
+      }
+      if (info.isMCoordinate()) {
+         n++;
+      }
+      return n;
    }
 }

--- a/src/main/java/liquibase/ext/spatial/sqlgenerator/OracleWktCoordiantesProcessor.java
+++ b/src/main/java/liquibase/ext/spatial/sqlgenerator/OracleWktCoordiantesProcessor.java
@@ -1,0 +1,474 @@
+package liquibase.ext.spatial.sqlgenerator;
+
+import java.io.IOException;
+import java.io.StreamTokenizer;
+import java.io.StringReader;
+import java.util.List;
+
+/**
+ * This class process a WKT string to generate the <code>SDO_ELEM_INFO</code>
+ * and <code>SDO_ORDINATES</code> to use in <code>SDO_GEOMETRY</code> Object
+ * constructor. <br/>
+ * This class is based on <em>JTS</em> <code>WKTReader</code> implementation. <br/>
+ * This class parses a OGC WKT v1.2 specification (except <code>tim</code>,
+ * <code>triangle</code> and <code>polyhedralSurface</code>)
+ * 
+ */
+public class OracleWktCoordiantesProcessor {
+
+   private static final String SDO_ETYPE_POINT = "1";
+   private static final String SDO_ETYPE_LINESTRING = "2";
+   private static final String SDO_ETYPE_POLYGON_EXT = "1003";
+   private static final String SDO_ETYPE_POLYGON_INT = "2003";
+
+   private static final String SDO_INTERPRETATION_POINT = "1";
+
+   private static final String EMPTY = "EMPTY";
+   private static final String COMMA = ",";
+   private static final String L_PAREN = "(";
+   private static final String R_PAREN = ")";
+   private static final String NAN_SYMBOL = "NaN";
+
+   private StreamTokenizer tokenizer = null;
+
+   private List<String> elementInfoArray;
+   private List<String> ordinatesArray;
+
+   /**
+    * Fill <code>elementInfoArray</code> and <code>coordinates</code> based on
+    * <code>wkt</code> data
+    * 
+    * @param wkt
+    * @throws IOException
+    * @throws IllegalStateException when problem found on WKT format
+    */
+   public void process(String wkt, List<String> elementInfoArray,
+         List<String> coordinates) throws IOException {
+
+      if (tokenizer != null) {
+         throw new IllegalStateException(
+               "Already processing. Use a new instance.");
+      }
+      StringReader reader = null;
+      try {
+         reader = new StringReader(wkt);
+         tokenizer = new StreamTokenizer(reader);
+
+         tokenizer.resetSyntax();
+         tokenizer.wordChars('a', 'z');
+         tokenizer.wordChars('A', 'Z');
+         tokenizer.wordChars(128 + 32, 255);
+         tokenizer.wordChars('0', '9');
+         tokenizer.wordChars('-', '-');
+         tokenizer.wordChars('+', '+');
+         tokenizer.wordChars('.', '.');
+         tokenizer.whitespaceChars(0, ' ');
+         tokenizer.commentChar('#');
+
+         this.elementInfoArray = elementInfoArray;
+         this.ordinatesArray = coordinates;
+
+         readGeometryTaggedText(null);
+
+      }
+      finally {
+         if (reader != null) {
+            reader.close();
+         }
+         tokenizer = null;
+         this.elementInfoArray = null;
+         this.ordinatesArray = null;
+      }
+   }
+
+   /**
+    * Read and load from current position a tagged geometry. <br/>
+    * Examples: <code>POINT (1 1)</code>
+    * <code>LINESTRING M (1 1 0, 2 2 1)</code>
+    * 
+    * @param previousDimensions to check dimension of
+    *        <code>GEOMETRYCOLLECTION</code> sub items
+    * @throws IOException
+    */
+   private void readGeometryTaggedText(Integer previousDimensions)
+         throws IOException {
+      String type = null;
+
+      try {
+         type = getNextWord();
+      }
+      catch (IOException e) {
+         throw new IllegalArgumentException("Parse error", e);
+      }
+      if (type == null) {
+         throw new IllegalArgumentException(
+               "Invalid WKT: geometry type expected");
+      }
+      type = type.toUpperCase();
+      int dimensions = 2;
+
+      // Get next word without move parser pointer
+      String nextWord = lookaheadWord();
+      if (nextWord == null || nextWord.isEmpty()) {
+         // unexpected string
+         throw new IllegalArgumentException(
+               "Invalid WKT: expected '(', 'Z', 'ZM' or 'M'.");
+      }
+      else if (L_PAREN.equals(nextWord)) {
+         if (type.endsWith("M")) {
+            type = type.substring(0, type.length() - 1);
+            dimensions++;
+         }
+         if (type.endsWith("Z")) {
+            type = type.substring(0, type.length() - 1);
+            dimensions++;
+         }
+      }
+      else {
+         // Move parse pointer (to skip word to process)
+         nextWord = getNextWord();
+         if ("ZM".equalsIgnoreCase(nextWord)) {
+            dimensions++;
+            dimensions++;
+         }
+         else if ("Z".equalsIgnoreCase(nextWord)
+               || "M".equalsIgnoreCase(nextWord)) {
+            dimensions++;
+         }
+         else {
+            // unexpected string
+            throw new IllegalArgumentException(
+                  "Invalid WKT: Unexpected string: ".concat(nextWord));
+         }
+      }
+      
+      // check parent (collection) previous dimension
+      if (previousDimensions != null) {
+         // Check parent dimensions
+         if (previousDimensions != dimensions) {
+            throw new IllegalArgumentException(
+                  "Invalid WKT: Mixed geometries with different dimensions");
+         }
+
+      }
+
+      // Read geometries
+      if ("POINT".equalsIgnoreCase(type)) {
+         readPointText(dimensions);
+      }
+      else if ("LINESTRING".equalsIgnoreCase(type)) {
+         readLineStringText(dimensions);
+      }
+      else if ("POLYGON".equalsIgnoreCase(type)) {
+         readPolygonText(dimensions);
+      }
+      else if ("MULTIPOINT".equalsIgnoreCase(type)) {
+         readMultiPointText(dimensions);
+      }
+      else if ("MULTILINESTRING".equalsIgnoreCase(type)) {
+         readMultiLineStringText(dimensions);
+      }
+      else if ("MULTIPOLYGON".equalsIgnoreCase(type)) {
+         readMultiPolygonText(dimensions);
+      }
+      else if ("GEOMETRYCOLLECTION".equalsIgnoreCase(type)) {
+         readGeometryCollectionText(dimensions);
+      }
+      else {
+         throw new IllegalArgumentException(String.format(
+               "Unknown geometry type: ", type));
+      }
+   }
+
+   /**
+    * Gets next word of parser cursor
+    * 
+    * @return next work token
+    * @throws IOException
+    * @throws IllegalArgumentException if next token is not a word
+    */
+   private String getNextWord() throws IOException {
+      return getNextWord(false);
+   }
+
+   /**
+    * Gets next word of parser cursor
+    * 
+    * @param optional
+    * @return next word token (or null if next token is not a word and
+    *         <code>optional</code> is <code>true</code>)
+    * @throws IOException
+    * @throws IllegalArgumentException if next token is not a word and
+    *         <code>optional</code> is <code>false</code>
+    */
+   private String getNextWord(boolean optional) throws IOException {
+      int type = tokenizer.nextToken();
+      switch (type) {
+      case StreamTokenizer.TT_WORD:
+
+         String word = tokenizer.sval;
+         if (word.equalsIgnoreCase(EMPTY))
+            return EMPTY;
+         return word;
+
+      case '(':
+         return L_PAREN;
+      case ')':
+         return R_PAREN;
+      case ',':
+         return COMMA;
+      }
+      if (optional) {
+         return null;
+      }
+      else {
+         throw new IllegalArgumentException("Invalid WKT");
+      }
+   }
+
+   /**
+    * Gets next word on parser cursor without move forward it.
+    * 
+    * @return next token if it's a work token, otherwise <code>null</code>
+    * @throws IOException
+    */
+   private String lookaheadWord() throws IOException {
+      String nextWord = getNextWord(true);
+      tokenizer.pushBack();
+      return nextWord;
+   }
+
+   /**
+    * Read and load a <code>GEOMETRYCOLLECTION</code> data
+    * 
+    * @param dimensions of coordinates
+    * @throws IOException
+    */
+   private void readGeometryCollectionText(int dimensions) throws IOException {
+      String nextToken = getNextOpener();
+      do {
+         readGeometryTaggedText(dimensions);
+         nextToken = getNextCloserOrComma();
+      } while (nextToken.equals(COMMA));
+
+   }
+
+   /**
+    * Read and load a <code>MULTIPOINT</code> data
+    * 
+    * @param dimensions of coordinates
+    * @throws IOException
+    */
+   private void readMultiPointText(int dimensions) throws IOException {
+      String nextToken = getNextOpener();
+      do {
+         addElementInfo(getCurrentOffset(), SDO_ETYPE_POINT, "1");
+         loadCoordinate(dimensions);
+         nextToken = getNextCloserOrComma();
+      } while (nextToken.equals(COMMA));
+   }
+
+   /**
+    * Read and load a <code>MULTIPOLYGON</code> data
+    * 
+    * @param dimensions of coordinates
+    * @throws IOException
+    */
+   private void readMultiPolygonText(int dimensions) throws IOException {
+      String nextToken = getNextOpener();
+      do {
+         readPolygonText(dimensions);
+         nextToken = getNextCloserOrComma();
+      } while (nextToken.equals(COMMA));
+   }
+
+   /**
+    * Read and load a <code>MULTILINESTRING</code> data
+    * 
+    * @param dimensions of coordinates
+    * @throws IOException
+    */
+   private void readMultiLineStringText(int dimensions) throws IOException {
+      String nextToken = getNextOpener();
+      do {
+         readLineStringText(dimensions);
+         nextToken = getNextCloserOrComma();
+      } while (nextToken.equals(COMMA));
+   }
+
+   /**
+    * @return current ordinatesArray offset
+    */
+   private int getCurrentOffset() {
+      return ordinatesArray.size() + 1;
+   }
+
+   /**
+    * Read and load a <code>POINT</code> data
+    * 
+    * @param dimensions of coordinates
+    * @throws IOException
+    */
+   private void readPointText(int dimensions) throws IOException {
+      getNextOpener();
+      addElementInfo(getCurrentOffset(), SDO_ETYPE_POINT,
+            SDO_INTERPRETATION_POINT);
+      loadCoordinate(dimensions);
+      getNextCloser();
+   }
+
+   /**
+    * Read and load a <code>LINESTRING</code> data
+    * 
+    * @param dimensions of coordinates
+    * @throws IOException
+    */
+   private void readLineStringText(int dimensions) throws IOException {
+      getNextOpener();
+      addElementInfo(getCurrentOffset(), SDO_ETYPE_LINESTRING, "1");
+      loadCoordinates(dimensions);
+   }
+
+   /**
+    * Read and load a <code>POLYGON</code> data
+    * 
+    * @param dimensions of coordinates
+    * @throws IOException
+    */
+   private void readPolygonText(int dimensions) throws IOException {
+      // Polygon group opener
+      String nextToken = getNextOpener();
+      // External polygon starts
+      getNextOpener();
+      addElementInfo(getCurrentOffset(), SDO_ETYPE_POLYGON_EXT, "1");
+      loadCoordinates(dimensions);
+      nextToken = getNextCloserOrComma();
+      while (nextToken.equals(COMMA)) {
+         // Internal polygon starts
+         getNextOpener();
+         addElementInfo(getCurrentOffset(), SDO_ETYPE_POLYGON_INT, "1");
+         loadCoordinates(dimensions);
+         nextToken = getNextCloserOrComma();
+      }
+   }
+
+   /**
+    * Read and load a single Geometry coordinate into {@link #ordinatesArray}
+    * 
+    * @param dimensions of coordinates
+    * @throws IOException
+    */
+   private void loadCoordinate(int dimensions) throws IOException {
+      for (int i = 0; i < dimensions; i++) {
+         ordinatesArray.add(getNextNumber());
+      }
+   }
+
+   /**
+    * Read and load a list of Geometry coordinate into {@link #ordinatesArray}
+    * 
+    * @param dimensions of coordinates
+    * @throws IOException
+    * @return number of coordinates (groups of ordinates) loaded
+    */
+   private int loadCoordinates(int dimensions) throws IOException {
+      String nextToken;
+      int count = 0;
+      do {
+         loadCoordinate(dimensions);
+         count++;
+         nextToken = getNextCloserOrComma();
+      } while (nextToken.equals(COMMA));
+      return count;
+   }
+
+   /**
+    * @return next Opener (left parenthesis) token
+    * @throws IOException
+    * @throws IllegalArgumentException if founds an empty token (not supported)
+    * @throws IllegalArgumentException if founds other kind of token
+    */
+   private String getNextOpener() throws IOException {
+      String nextWord = getNextWord();
+      if (nextWord.equals(L_PAREN)) {
+         return nextWord;
+      }
+      else if (nextWord.equals(EMPTY)) {
+         throw new IllegalArgumentException("Empty geometries not supported");
+      }
+      throw new IllegalArgumentException("Invalid WKT: " + EMPTY + " or "
+            + L_PAREN + " expected");
+   }
+
+   /**
+    * @return next valid number token
+    * @throws IOException
+    * @throws IllegalArgumentException if founds other kind of token or gots a
+    *         number format exception
+    */
+   private String getNextNumber() throws IOException {
+      int type = tokenizer.nextToken();
+      switch (type) {
+      case StreamTokenizer.TT_WORD: {
+         if (tokenizer.sval.equalsIgnoreCase(NAN_SYMBOL)) {
+            throw new IllegalArgumentException("Invalid WKT: NaN not supported");
+         }
+         else {
+            try {
+               // Check it's valid number
+               Double.parseDouble(tokenizer.sval);
+               // Return original string (avoid lost of precision)
+               return tokenizer.sval;
+            }
+            catch (NumberFormatException ex) {
+               throw new IllegalArgumentException(
+                     "Invalid WKT: Invalid number: " + tokenizer.sval);
+            }
+         }
+      }
+      }
+      throw new IllegalArgumentException("Invalid WKT: Expected number");
+   }
+
+   /**
+    * Adds a triplet data on {@link #elementInfoArray}
+    * 
+    * @param offset
+    * @param sdoEtype
+    * @param sdoInterpretation
+    */
+   private void addElementInfo(int offset, String sdoEtype,
+         String sdoInterpretation) {
+      this.elementInfoArray.add(String.valueOf(offset));
+      this.elementInfoArray.add(sdoEtype);
+      this.elementInfoArray.add(sdoInterpretation);
+   }
+
+   /**
+    * @return next closer (right parenthesis) token
+    * @throws IOException
+    * @throws IllegalArgumentException if next token is not a closer
+    */
+   private String getNextCloser() throws IOException {
+      String nextWord = getNextWord();
+      if (nextWord.equals(R_PAREN)) {
+         return nextWord;
+      }
+      throw new IllegalArgumentException("Invalid WKT: " + R_PAREN
+            + " expected");
+   }
+
+   /**
+    * @return next closer (right parenthesis) or comma token
+    * @throws IOException
+    * @throws IllegalArgumentException if next token is not a closer nor comma
+    */
+   private String getNextCloserOrComma() throws IOException {
+      String nextWord = getNextWord();
+      if (nextWord.equals(COMMA) || nextWord.equals(R_PAREN)) {
+         return nextWord;
+      }
+      throw new IllegalArgumentException("Invalid WKT: " + COMMA + " or "
+            + R_PAREN + " expected");
+   }
+}

--- a/src/main/java/liquibase/ext/spatial/sqlgenerator/SpatialInsertGeneratorOracle.java
+++ b/src/main/java/liquibase/ext/spatial/sqlgenerator/SpatialInsertGeneratorOracle.java
@@ -1,7 +1,15 @@
 package liquibase.ext.spatial.sqlgenerator;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import liquibase.database.Database;
 import liquibase.database.core.OracleDatabase;
+import liquibase.ext.spatial.sqlgenerator.WktConversionUtils.EWKTInfo;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.statement.core.InsertStatement;
 
 /**
@@ -9,6 +17,8 @@ import liquibase.statement.core.InsertStatement;
  * geometries into Oracle.
  */
 public class SpatialInsertGeneratorOracle extends AbstractSpatialInsertGenerator {
+   
+   private static final Sql[] EMPTY_SQL_ARRAY = new Sql[0];
    /**
     * Verifies that the <code>InsertStatement</code> has WKT or EWKT.
     */
@@ -33,8 +43,39 @@ public class SpatialInsertGeneratorOracle extends AbstractSpatialInsertGenerator
     */
    @Override
    public String convertToFunction(final String wkt, final String srid, final Database database) {
-      final String oracleWkt = OracleSpatialUtils.getOracleWkt(wkt);
-      final String oracleSrid = OracleSpatialUtils.getOracleSrid(srid, database);
-      return super.convertToFunction(oracleWkt, oracleSrid, database);
+      // Check if WKT is OGC v1.1 compliant (supported version in Oracle)
+      EWKTInfo info = WktConversionUtils.getWktInfo(wkt);
+      if (info.isV1_1()) {
+         // Use SDO_GEOMETRY(wkt) constructor
+         final String oracleWkt = OracleSpatialUtils.getOracleWkt(wkt);
+         final String oracleSrid = OracleSpatialUtils.getOracleSrid(srid, database);
+         return super.convertToFunction(oracleWkt, oracleSrid, database);
+      } else {
+         // Use SDO_GEOMETRY native constructor
+         return OracleSpatialUtils.getNativeOracleConstructor(info, srid, database);
+      }
+   }
+   
+   /** 
+    * {@inheritDoc}
+    * <br/>
+    * Overwrite to prevent problems about numeric parse with locale definition
+    *
+    * @see liquibase.ext.spatial.sqlgenerator.AbstractSpatialInsertGenerator#generateSql(liquibase.statement.core.InsertStatement, liquibase.database.Database, liquibase.sqlgenerator.SqlGeneratorChain)
+    */
+   @Override
+   public Sql[] generateSql(InsertStatement statement, Database database,
+         SqlGeneratorChain sqlGeneratorChain) {
+       // Prevent problems about numeric format (set numeric characters
+       // to US default locale)
+       List<Sql> sqls = new ArrayList<Sql>();
+       sqls.add(
+             new UnparsedSql(
+                   "alter session set NLS_NUMERIC_CHARACTERS = '.,'", 
+                   getAffectedTable(statement)));
+       
+       sqls.addAll(Arrays.asList(
+             super.generateSql(statement, database, sqlGeneratorChain)));
+       return sqls.toArray(EMPTY_SQL_ARRAY);
    }
 }

--- a/src/main/java/liquibase/ext/spatial/sqlgenerator/WktConversionUtils.java
+++ b/src/main/java/liquibase/ext/spatial/sqlgenerator/WktConversionUtils.java
@@ -8,17 +8,51 @@ import liquibase.database.Database;
 import com.vividsolutions.jts.geom.Geometry;
 
 public class WktConversionUtils {
+   
+   /**
+    * WKT Point geometry type
+    */
+   public static final String T_POINT = "POINT";
+
+   /**
+    * WKT Line string geometry type
+    */
+   public static final String T_LINESTRING = "LINESTRING";
+
+   /**
+    * WKT Polygon geometry type
+    */
+   public static final String T_POLYGON = "POLYGON";
+
+   /**
+    * WKT Geometry collection type
+    */
+   public static final String T_GEOMETRY_COLLECTION = "GEOMETRYCOLLECTION";
+   
    /** The SRID regular expression. */
    public static final String SRID_REGEX = "SRID[\\s]*=[\\s]*([0-9]+)[\\s]*;";
+   
 
    /** The WKT regular expression. */
-   public static final String WKT_REGEX = "((((MULTI)?(POINT|LINESTRING|POLYGON)|GEOMETRYCOLLECTION)Z?M?)[\\s]*[(].*[)])";
+   public static final String WKT_REGEX = "((((MULTI)?("+T_POINT+"|"+T_LINESTRING+"|"+T_POLYGON+")|"+ T_GEOMETRY_COLLECTION+ ")[\\s]?(Z)?(M)?)[\\s]*[(](.*)[)])";
 
    /** The PostGIS EWKT regular expression. */
-   public static final String EWKT_REGEX = "(" + SRID_REGEX + "[\\s]*)?" + WKT_REGEX;
+   public static final String EWKT_REGEX = "(" + SRID_REGEX + "([\\s]*))?" + WKT_REGEX;
 
    /** The EWKT <code>Pattern</code> instance. */
    public static final Pattern EWKT_PATTERN = Pattern.compile(EWKT_REGEX, Pattern.CASE_INSENSITIVE);
+   
+   /** EWKT <code>Pattern</code> groups constants **/
+   public static final int G_SRID_DEFINITION = 1;
+   public static final int G_SRID = 2;
+   public static final int G_WKT_WITHOUT_SRID = 4;
+   public static final int G_GEOMETRY_TYPE = 5;
+   public static final int G_GEOMETRY_OR_COLLECTION = 6;
+   public static final int G_MULTI = 7;
+   public static final int G_BASE_GEOMETRY_TYPE = 8;
+   public static final int G_HAS_Z = 9;
+   public static final int G_HAS_M = 10;
+   public static final int G_DATA = 11;
 
    /** Hide the default constructor. */
    private WktConversionUtils() {
@@ -50,8 +84,8 @@ public class WktConversionUtils {
          final String value = oldValue.toString().trim();
          final Matcher matcher = EWKT_PATTERN.matcher(value);
          if (matcher.matches()) {
-            final String sridString = matcher.group(2);
-            final String wkt = matcher.group(3);
+            final String sridString = matcher.group(G_SRID);
+            final String wkt = matcher.group(G_WKT_WITHOUT_SRID);
             final String function = generator.convertToFunction(wkt, sridString, database);
             newValue = function;
          }
@@ -88,5 +122,212 @@ public class WktConversionUtils {
       }
       function += ")";
       return function;
+   }
+   
+    /**
+     * Parse information about a WKT 
+     * 
+     * @param wkt
+     * @return
+     */
+    public static EWKTInfo getWktInfo(String wkt) {
+        if (wkt == null || wkt.equals("")) {
+            throw new IllegalArgumentException("The Well-Known Text cannot be null or empty");
+         }
+        final String value = wkt.trim();
+        final Matcher matcher = EWKT_PATTERN.matcher(value);
+        if (matcher.matches()) {
+            return new EWKTInfo(value, matcher);
+        } else {
+            throw new IllegalArgumentException("The Well-Known Text invalid");
+        }
+    }
+   
+    /**
+     * Object which contains useful information about a WKT string 
+     */
+    public static class EWKTInfo {
+
+        private final String originalWkt;
+
+        private final String wktWithoutSRID;
+
+        private final boolean isV1_1;
+
+        private final String srid;
+        
+        private final String geometryType;
+
+        private final String geometryBaseType;
+
+        private final boolean mCoordinate;
+
+        private final boolean zCoordinate;
+        
+        private final boolean isMulti;
+
+        private final boolean isCollection;
+
+        private final String data;
+        
+        private EWKTInfo(String originalWkt, Matcher ewktMatcher) {
+            this.originalWkt = originalWkt;
+            final String sridString = ewktMatcher.group(G_SRID);
+            if (sridString == null || sridString.isEmpty()){
+                srid = null;
+            } else {
+                srid = sridString;
+            }
+            wktWithoutSRID = ewktMatcher.group(G_WKT_WITHOUT_SRID);
+            zCoordinate = "Z".equalsIgnoreCase(ewktMatcher.group(G_HAS_Z));
+            mCoordinate = "M".equalsIgnoreCase(ewktMatcher.group(G_HAS_M));
+            isCollection = T_GEOMETRY_COLLECTION.equalsIgnoreCase(ewktMatcher.group(G_GEOMETRY_OR_COLLECTION));
+            if (isCollection) {
+                geometryBaseType = T_GEOMETRY_COLLECTION;
+                String tmpGeometryType= T_GEOMETRY_COLLECTION;
+                if (this.zCoordinate) {
+                   tmpGeometryType = tmpGeometryType.concat("Z");
+                }
+                if (this.mCoordinate) {
+                   tmpGeometryType = tmpGeometryType.concat("M");
+                }
+                geometryType = tmpGeometryType;
+            } else {
+               geometryType = ewktMatcher.group(G_GEOMETRY_TYPE).toUpperCase().replaceAll("[\\s]", "");
+               if (geometryType == null) {
+                  throw new IllegalArgumentException("Invalid WKT: Missing geomtry type");
+               }
+               geometryBaseType = ewktMatcher.group(G_BASE_GEOMETRY_TYPE).toUpperCase();
+            }
+            isMulti = "MULTI".equalsIgnoreCase(ewktMatcher.group(G_MULTI));
+            data = ewktMatcher.group(G_DATA);
+            isV1_1 = srid == null && !mCoordinate && !zCoordinate;
+        }
+
+        /**
+         * @return the original wkt string
+         */
+        public String getOriginalWkt() {
+            return originalWkt;
+        }
+
+        /**
+         * @return the SRID (if any)
+         */
+        public String getSrid() {
+            return srid;
+        }
+
+        /**
+         * @return geometry type (POINT, MULTIPOINT, POINTZM,....)
+         */
+        public String getGeometryType() {
+            return geometryType;
+        }
+
+        /**
+         * @return geometry type has M coordinate
+         */
+        public boolean isMCoordinate() {
+            return mCoordinate;
+        }
+
+        /**
+         * @return geometry type has Z coordinate
+         */
+        public boolean isZCoordinate() {
+            return zCoordinate;
+        }
+
+        /**
+         * @return coordinates (or geometry collection) part of WKT
+         */
+        public String getData() {
+            return data;
+        }
+
+        /**
+         * @return is WKT full suitable of OGC WKT 1.1 version
+         */
+        public boolean isV1_1() {
+            return isV1_1;
+        }
+
+        /**
+         * @return is Multi geometry
+         */
+        public boolean isMulti() {
+            return isMulti;
+        }
+
+        /**
+         * @return is a Geometry Collection
+         */
+        public boolean isCollection() {
+            return isCollection;
+        }
+        
+        /**
+         * @return geometry base type (one of 'POINT', 'LINESTRING', 'POLYGON')
+         */
+        public String getGeometryBaseType() {
+            return geometryBaseType;
+        }
+
+      /**
+       * @return original WKT without SRID definition part
+       */
+      public String getWktWithoutSRID() {
+         return wktWithoutSRID;
+      }
+    }
+
+   /**
+    * Informs if OGC <code>geometryType</code> is defined with <em>Z</em>
+    * coordinates.<br/>
+    * Examples:<ul>
+    * <li><code>Linestring z</code> return true </li>
+    * <li><code>LinestringZ</code> return true </li>
+    * <li><code>LinestringZm</code> return true </li>
+    * <li><code>Linestring Zm</code> return true </li>
+    * <li><code>Linestring m</code> return false </li>
+    * <li><code>Linestringm</code> return false </li>
+    * <li><code>Linestring</code> return false </li>
+    * </ul>
+    * 
+    * @param geometryType
+    * @return
+    */
+   public static boolean hasZGeometryType(String geometryType) {
+      if (geometryType == null) {
+         return false;
+      }
+      geometryType = geometryType.replaceAll("\\s","").toUpperCase();
+      return geometryType.endsWith("Z") || geometryType.endsWith("ZM");
+   }
+
+   /**
+    * Informs if OGC <code>geometryType</code> is defined with <em>Z</em>
+    * coordinates.<br/>
+    * Examples:<ul>
+    * <li><code>Linestring z</code> return false </li>
+    * <li><code>LinestringZ</code> return false </li>
+    * <li><code>LinestringZM</code> return true </li>
+    * <li><code>Linestring Zm</code> return true </li>
+    * <li><code>Linestring m</code> return true </li>
+    * <li><code>LinestringM</code> return true </li>
+    * <li><code>Linestringm</code> return true </li>
+    * <li><code>Linestring</code> return false </li>
+    * </ul>
+    * 
+    * @param geometryType
+    * @return
+    */
+   public static boolean hasMGeometryType(String geometryType) {
+      if (geometryType == null) {
+         return false;
+      }
+      geometryType = geometryType.replaceAll("\\s","").toUpperCase();
+      return geometryType.endsWith("M");
    }
 }

--- a/src/test/java/liquibase/ext/spatial/sqlgenerator/OracleSpatialUtilsTest.java
+++ b/src/test/java/liquibase/ext/spatial/sqlgenerator/OracleSpatialUtilsTest.java
@@ -1,0 +1,90 @@
+package liquibase.ext.spatial.sqlgenerator;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import liquibase.database.Database;
+import liquibase.ext.spatial.sqlgenerator.WktConversionUtils.EWKTInfo;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * <code>OracleSpatialUtilsTest</code> tests {@link OracleSpatialUtils}.
+ */
+public class OracleSpatialUtilsTest {
+   
+   
+   /**
+    * Test 
+    * {@link OracleSpatialUtils#getNativeOracleConstructor(liquibase.ext.spatial.sqlgenerator.WktConversionUtils.EWKTInfo, liquibase.database.Database)} 
+    */
+   @Test(dataProvider="getNativeOracleConstructorTestData")
+   public void testGetNativeOracleConstructor(String wkt, String expression) {
+      EWKTInfo info = WktConversionUtils.getWktInfo(wkt);
+      final Database database = mock(Database.class);
+      String result = OracleSpatialUtils.getNativeOracleConstructor(info,null, database);
+      assertEquals(result, expression);
+   }
+   
+   @DataProvider
+   public Object[][] getNativeOracleConstructorTestData(){
+      return new Object[][]{
+            // POINT
+            new Object[]{"Point(10 10)", "SDO_GEOMETRY(2001,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1,1),SDO_ORDINATE_ARRAY(10.0,10.0))"},
+            new Object[]{"PointM(10 10 3)", "SDO_GEOMETRY(3301,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1,1),SDO_ORDINATE_ARRAY(10.0,10.0,3.0))"},
+            new Object[]{"PointZ(10 10 3)", "SDO_GEOMETRY(3001,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1,1),SDO_ORDINATE_ARRAY(10.0,10.0,3.0))"},
+            new Object[]{"Point ZM(10 10 3 1)", "SDO_GEOMETRY(4401,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1,1),SDO_ORDINATE_ARRAY(10.0,10.0,3.0,1.0))"},
+            new Object[]{"MultiPoint(10.0 10, 20 20, 30 30)", "SDO_GEOMETRY(2005,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1,1,3,1,1,5,1,1),SDO_ORDINATE_ARRAY(10.0,10.0,20.0,20.0,30.0,30.0))"},
+            new Object[]{"MultiPointM(10.0 10 1, 20 20 2, 30 30 1)", "SDO_GEOMETRY(3305,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1,1,4,1,1,7,1,1),SDO_ORDINATE_ARRAY(10.0,10.0,1.0,20.0,20.0,2.0,30.0,30.0,1.0))"},
+            new Object[]{"MultiPointzM(10.0 10 1 1, 20 20 2 2, 30 30 1 1)", "SDO_GEOMETRY(4405,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1,1,5,1,1,9,1,1),SDO_ORDINATE_ARRAY(10.0,10.0,1.0,1.0,20.0,20.0,2.0,2.0,30.0,30.0,1.0,1.0))"},
+            
+            // LINESTRING
+            new Object[]{"LineSTring(10 10, 20 20)", "SDO_GEOMETRY(2002,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,2,1),SDO_ORDINATE_ARRAY(10.0,10.0,20.0,20.0))"},
+            new Object[]{"linestring M(10 10 3, 20 20 1)", "SDO_GEOMETRY(3302,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,2,1),SDO_ORDINATE_ARRAY(10.0,10.0,3.0,20.0,20.0,1.0))"},
+            new Object[]{"LINESTRINGZM(10 10 3 1, 20 20 1 1, 30 30 2 2)", "SDO_GEOMETRY(4402,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,2,1),SDO_ORDINATE_ARRAY(10.0,10.0,3.0,1.0,20.0,20.0,1.0,1.0,30.0,30.0,2.0,2.0))"},
+            new Object[]{"MultiLINESTRING((10 10, 20 20),(30 30, 2 2))", "SDO_GEOMETRY(2006,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,2,1,5,2,1),SDO_ORDINATE_ARRAY(10.0,10.0,20.0,20.0,30.0,30.0,2.0,2.0))"},
+            new Object[]{"MultiLINESTRING z((10 10 1, 20 20 1),(30 30 1, 2 2 1))", "SDO_GEOMETRY(3006,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,2,1,7,2,1),SDO_ORDINATE_ARRAY(10.0,10.0,1.0,20.0,20.0,1.0,30.0,30.0,1.0,2.0,2.0,1.0))"},
+            
+            
+            // Polygon
+            new Object[]{"Polygon((10 10, 20 20, 10 10))", "SDO_GEOMETRY(2003,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1003,1),SDO_ORDINATE_ARRAY(10.0,10.0,20.0,20.0,10.0,10.0))"},
+            new Object[]{"    Polygon Z(  (10 10 1   , 20 20 1, 10 10 1))", "SDO_GEOMETRY(3003,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1003,1),SDO_ORDINATE_ARRAY(10.0,10.0,1.0,20.0,20.0,1.0,10.0,10.0,1.0))"},
+            new Object[]{"Polygon m((10 10 1, 20 20 1, 10 10 1))", "SDO_GEOMETRY(3303,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1003,1),SDO_ORDINATE_ARRAY(10.0,10.0,1.0,20.0,20.0,1.0,10.0,10.0,1.0))"},
+            new Object[]{"PolygonZm((10 10 1 1, 20 20      1 1, 10 10 1 1))", "SDO_GEOMETRY(4403,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1003,1),SDO_ORDINATE_ARRAY(10.0,10.0,1.0,1.0,20.0,20.0,1.0,1.0,10.0,10.0,1.0,1.0))"},
+            new Object[]{"  Polygon((10 10, 20 20, 10 10),(11.0 11.0, 19.0 19.0, 11.0 11))", "SDO_GEOMETRY(2003,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1003,1,7,2003,1),SDO_ORDINATE_ARRAY(10.0,10.0,20.0,20.0,10.0,10.0,11.0,11.0,19.0,19.0,11.0,11.0))"},
+            new Object[]{"Polygonz((10 10 1, 20 20 1, 10 10 1),(11.0 11.0 1, 19.0 19.0 1, 11.0 11 1))", "SDO_GEOMETRY(3003,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1003,1,10,2003,1),SDO_ORDINATE_ARRAY(10.0,10.0,1.0,20.0,20.0,1.0,10.0,10.0,1.0,11.0,11.0,1.0,19.0,19.0,1.0,11.0,11.0,1.0))"},
+            new Object[]{" Polygonm((10 10 1, 20 20 1, 10 10 1),(11.0 11.0 1, 19.0 19.0 1, 11.0 11 1))", "SDO_GEOMETRY(3303,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1003,1,10,2003,1),SDO_ORDINATE_ARRAY(10.0,10.0,1.0,20.0,20.0,1.0,10.0,10.0,1.0,11.0,11.0,1.0,19.0,19.0,1.0,11.0,11.0,1.0))"},
+            new Object[]{"MULTIPolygon(((10 10, 20 20, 10 10))      ,((10 10, 20 20, 10 10)))", "SDO_GEOMETRY(2007,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1003,1,7,1003,1),SDO_ORDINATE_ARRAY(10.0,10.0,20.0,20.0,10.0,10.0,10.0,10.0,20.0,20.0,10.0,10.0))"},
+            
+            
+            // Geometry collections
+            new Object[]{"  Geometrycollection  (Point(10    10), Linestring(11 11, 15 15))", "SDO_GEOMETRY(2004,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1,1,3,2,1),SDO_ORDINATE_ARRAY(10.0,10.0,11.0,11.0,15.0,15.0))"},
+            new Object[]{" Geometrycollection z (         Pointz(10 10 1), Linestring Z(11 11 1, 15 15 1))", "SDO_GEOMETRY(3004,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1,1,4,2,1),SDO_ORDINATE_ARRAY(10.0,10.0,1.0,11.0,11.0,1.0,15.0,15.0,1.0))"},
+            new Object[]{"  Geometrycollection m (Pointm(10 10 1), Linestring M(11 11 1, 15 15 1))", "SDO_GEOMETRY(3304,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1,1,4,2,1),SDO_ORDINATE_ARRAY(10.0,10.0,1.0,11.0,11.0,1.0,15.0,15.0,1.0))"},
+            new Object[]{"GeometryCOLLECTION(MULTIPolygon(((10 10, 20 20, 10 10)),((10 10, 20 20, 10 10))), POINT(1 1))", "SDO_GEOMETRY(2004,NULL,NULL,SDO_ELEM_INFO_ARRAY(1,1003,1,7,1003,1,13,1,1),SDO_ORDINATE_ARRAY(10.0,10.0,20.0,20.0,10.0,10.0,10.0,10.0,20.0,20.0,10.0,10.0,1.0,1.0))"},
+             
+      };
+      
+   }
+   
+   /**
+    * Test 
+    * {@link OracleSpatialUtils#getNativeOracleConstructor(EWKTInfo, String, Integer, Database)}
+    * 
+    */
+   @Test(dataProvider="getNativeOracleConstructorLongTestData")
+   public void testGetNativeOracleConstructorLong(String wkt,Integer limit, String expression) {
+      EWKTInfo info = WktConversionUtils.getWktInfo(wkt);
+      final Database database = mock(Database.class);
+      String result = OracleSpatialUtils.getNativeOracleConstructor(info,null, limit, database);
+      assertEquals(result, expression);
+   }
+   @DataProvider
+   public Object[][] getNativeOracleConstructorLongTestData(){
+      return new Object[][]{
+            new Object[]{"GeometryCOLLECTION(MULTIPolygon(((10 10, 20 20, 10 10)),((10 10, 20 20, 10 10))), POINT(1 1))", 3, "SDO_GEOMETRY(2004,NULL,NULL,(select cast(multiset(select to_number(x.column_value.extract('v/text()'))c from table(xmlsequence(xmltype('<r><v>1</v><v>1003</v><v>1</v><v>7</v><v>1003</v><v>1</v><v>13</v><v>1</v><v>1</v></r>').extract('r/v')))x)as SDO_ELEM_INFO_ARRAY)from dual),(select cast(multiset(select to_number(x.column_value.extract('v/text()'))c from table(xmlsequence(xmltype('<r><v>10</v><v>10</v><v>20</v><v>20</v><v>10</v><v>10</v><v>10</v><v>10</v><v>20</v><v>20</v><v>10</v><v>10</v><v>1</v><v>1</v></r>').extract('r/v')))x)as SDO_ORDINATE_ARRAY)from dual))"},
+            new Object[]{"GeometryCOLLECTION(MULTIPolygon(((10.1 10.1, 20.1 20.1, 10.1 10.1)),((10.1 10.1, 20.1 20.1, 10.1 10.1))), POINT(1 1))", 3, "SDO_GEOMETRY(2004,NULL,NULL,(select cast(multiset(select to_number(x.column_value.extract('v/text()'))c from table(xmlsequence(xmltype('<r><v>1</v><v>1003</v><v>1</v><v>7</v><v>1003</v><v>1</v><v>13</v><v>1</v><v>1</v></r>').extract('r/v')))x)as SDO_ELEM_INFO_ARRAY)from dual),(select cast(multiset(select to_number(x.column_value.extract('v/text()'))c from table(xmlsequence(xmltype('<r><v>10.1</v><v>10.1</v><v>20.1</v><v>20.1</v><v>10.1</v><v>10.1</v><v>10.1</v><v>10.1</v><v>20.1</v><v>20.1</v><v>10.1</v><v>10.1</v><v>1</v><v>1</v></r>').extract('r/v')))x)as SDO_ORDINATE_ARRAY)from dual))"},
+      };
+   }
+}

--- a/src/test/java/liquibase/ext/spatial/sqlgenerator/OracleWktCoordiantesProcessorTest.java
+++ b/src/test/java/liquibase/ext/spatial/sqlgenerator/OracleWktCoordiantesProcessorTest.java
@@ -1,0 +1,124 @@
+package liquibase.ext.spatial.sqlgenerator;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import liquibase.util.StringUtils;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * <code>OracleWktCoordiantesProcessorTest</code> tests {@link OracleWktCoordiantesProcessor}.
+ */
+public class OracleWktCoordiantesProcessorTest {
+   
+   /**
+    * Tests {@link OracleWktCoordiantesProcessor#process(String, List, List)}
+    * 
+    * @param wkt
+    * @param elementInfo
+    * @param ordinates
+    * @throws Exception
+    */
+   @Test(dataProvider = "processData")
+   public void testProcessor(String wkt,String elementInfo, String ordinates) throws Exception{
+      OracleWktCoordiantesProcessor processor = new OracleWktCoordiantesProcessor();
+
+      List<String> elementInfoArray = new ArrayList<String>();
+      List<String> ordinateArray = new ArrayList<String>();
+      processor.process(wkt, elementInfoArray, ordinateArray);
+      assertEquals(StringUtils.join(elementInfoArray, ","), elementInfo);
+      assertEquals(StringUtils.join(ordinateArray, ","), ordinates);
+   }
+   
+   
+   @DataProvider
+   public Object[][] processData(){
+      return new Object[][] {
+            // Point
+            new Object[]{"Point(10 10)", "1,1,1", "10.0,10.0"},
+            new Object[]{"Pointz(10 10 5)", "1,1,1", "10.0,10.0,5.0"},
+            new Object[]{"Point m(10 10 5)", "1,1,1", "10.0,10.0,5.0"},
+            new Object[]{"Pointzm(10 10 5 6)", "1,1,1", "10.0,10.0,5.0,6.0"},
+            new Object[]{"MultiPOINT(10 10, 20 20, 30 30)", "1,1,1,3,1,1,5,1,1", "10.0,10.0,20.0,20.0,30.0,30.0"},
+            new Object[]{"MultiPOINTz(10 10 5, 20 20 5.5, 30 30 5.1)", "1,1,1,4,1,1,7,1,1", "10.0,10.0,5.0,20.0,20.0,5.5,30.0,30.0,5.1"},
+            
+            // LineString
+            new Object[]{"LineSTring(10 10,20 20,30 30)", "1,2,1", "10.0,10.0,20.0,20.0,30.0,30.0"},
+            new Object[]{"LineSTringz(10 10 1, 20 20 2, 30 30 3)", "1,2,1", "10.0,10.0,1.0,20.0,20.0,2.0,30.0,30.0,3.0"},
+            new Object[]{"LineSTring m(10 10 1, 20 20 2, 30 30 3)", "1,2,1", "10.0,10.0,1.0,20.0,20.0,2.0,30.0,30.0,3.0"},
+            new Object[]{"LineSTringzm(10 10 1 1, 20 20 2 2, 30 30 3 3)", "1,2,1", "10.0,10.0,1.0,1.0,20.0,20.0,2.0,2.0,30.0,30.0,3.0,3.0"},
+            new Object[]{" multiLineSTring ((10  10, 20 20, 30 30),(40 40, 50 50))", "1,2,1,7,2,1", "10.0,10.0,20.0,20.0,30.0,30.0,40.0,40.0,50.0,50.0"},
+            new Object[]{"    multiLineSTring z ((10     10 1, 20 20 2, 30 30 3) ,  (40 40 4, 50 50 5)   )  ", "1,2,1,10,2,1", "10.0,10.0,1.0,20.0,20.0,2.0,30.0,30.0,3.0,40.0,40.0,4.0,50.0,50.0,5.0"},
+            
+            // Polygon
+            new Object[]{"POLYGON ((10 10, 20 20, 30 30, 10 10))", "1,1003,1", "10.0,10.0,20.0,20.0,30.0,30.0,10.0,10.0"},
+            new Object[]{"POLYGON Z((10 10 1, 20 20 2, 30 30 3, 10 10 1))", "1,1003,1", "10.0,10.0,1.0,20.0,20.0,2.0,30.0,30.0,3.0,10.0,10.0,1.0"},
+            new Object[]{" polygon ((10 10, 20 20, 30 30, 10 10),(5.5 5.5, 6.6 6.6, 5.5 5.5),(8.8 8.8, 9.9 9.9, 8.8 8.8))", "1,1003,1,9,2003,1,15,2003,1", "10.0,10.0,20.0,20.0,30.0,30.0,10.0,10.0,5.5,5.5,6.6,6.6,5.5,5.5,8.8,8.8,9.9,9.9,8.8,8.8"},
+            new Object[]{" polygonm ((10 10 1, 20 20 2, 30 30 3, 10 10 1),(5.5 5.5 5, 6.6 6.6 6, 7.7 7.7 7),(8.8 8.8 8, 9.9 9.9 9, 9.5 9.5 9))", "1,1003,1,13,2003,1,22,2003,1", "10.0,10.0,1.0,20.0,20.0,2.0,30.0,30.0,3.0,10.0,10.0,1.0,5.5,5.5,5.0,6.6,6.6,6.0,7.7,7.7,7.0,8.8,8.8,8.0,9.9,9.9,9.0,9.5,9.5,9.0"},
+            new Object[]{" polygon zm   ((10 10 1 1, 20 20 2 2, 30 30 3 3, 10 10 1 1),(5.5 5.5 5 5, 6.6 6.6 6 6, 7.7 7.7 7 7),(8.8 8.8 8 8, 9.9 9.9 9 9, 9.5 9.5 9 9))", "1,1003,1,17,2003,1,29,2003,1", "10.0,10.0,1.0,1.0,20.0,20.0,2.0,2.0,30.0,30.0,3.0,3.0,10.0,10.0,1.0,1.0,5.5,5.5,5.0,5.0,6.6,6.6,6.0,6.0,7.7,7.7,7.0,7.0,8.8,8.8,8.0,8.0,9.9,9.9,9.0,9.0,9.5,9.5,9.0,9.0"},
+            new Object[]{" multipolygon (((10 10, 20 20, 30 30, 10 10),(5.5 5.5, 6.6 6.6, 7.7 7.7),(8.8 8.8, 9.9 9.9, 9.5 9.5)),((1 1, 2 2, 3 3, 1 1)))", "1,1003,1,9,2003,1,15,2003,1,21,1003,1", "10.0,10.0,20.0,20.0,30.0,30.0,10.0,10.0,5.5,5.5,6.6,6.6,7.7,7.7,8.8,8.8,9.9,9.9,9.5,9.5,1.0,1.0,2.0,2.0,3.0,3.0,1.0,1.0"},
+            new Object[]{" multipolygonm (((10 10 1, 20 20 2, 30 30 3, 10 10 1),(5.5 5.5 5, 6.6 6.6 6, 7.7 7.7 7),(8.8 8.8 8, 9.9 9.9 9, 9.5 9.5 9)),((1 1 1, 2 2 2, 3 3 3, 1 1 1)))", "1,1003,1,13,2003,1,22,2003,1,31,1003,1", "10.0,10.0,1.0,20.0,20.0,2.0,30.0,30.0,3.0,10.0,10.0,1.0,5.5,5.5,5.0,6.6,6.6,6.0,7.7,7.7,7.0,8.8,8.8,8.0,9.9,9.9,9.0,9.5,9.5,9.0,1.0,1.0,1.0,2.0,2.0,2.0,3.0,3.0,3.0,1.0,1.0,1.0"},
+            
+            // Geometry collection
+            new Object[]{" GeometryCollection(Point(10 10))", "1,1,1", "10.0,10.0"},
+            new Object[]{" GeometryCollection(Point(10 10),Point(20 20),Point(30 30))", "1,1,1,3,1,1,5,1,1", "10.0,10.0,20.0,20.0,30.0,30.0"},
+            new Object[]{" geometrycollection(Point(10 10),lineSTRING(20 20,30 30))", "1,1,1,3,2,1", "10.0,10.0,20.0,20.0,30.0,30.0"},
+            new Object[]{" GeometryCOllection(Point(10 10),lineSTRING(20 20,30 30), Point(10 10))", "1,1,1,3,2,1,7,1,1", "10.0,10.0,20.0,20.0,30.0,30.0,10.0,10.0"},
+            new Object[]{"  GEOMETRYCOLLECTIONM( Point m(10 10 5))", "1,1,1", "10.0,10.0,5.0"},
+            new Object[]{"  GEOMETRYCOLLECTION zM( Point zm(10 10 5 5.1), Point zm(10 10 5 5.1))", "1,1,1,5,1,1", "10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1"},
+            new Object[]{"  GEOMETRYCOLLECTIONzM( LInestRINGzm(10 10 5 5.1,10 10 5 5.1))", "1,2,1", "10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1"},
+            new Object[]{"gEOMETRYCOLLECTIONZm( LInestRINGzm(10 10 5 5.1,10 10 5 5.1), Point zm(10 10 5 5.1))", "1,2,1,9,1,1", "10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1"},
+            new Object[]{"gEOMETRYCOLLECTIONZm( polygonzm((10 10 5 5.1,10 10 5 5.1, 10 10 5 5.1)))", "1,1003,1", "10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1"},
+            new Object[]{"geometrycollectionzm( polygonzm((10 10 5 5.1,10 10 5 5.1, 10 10 5 5.1)), Point zm(10 10 5 5.1), linestringzm(10 10 5 5.1, 10 10 5 5.1))", "1,1003,1,13,1,1,17,2,1", "10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1"},
+            new Object[]{"geometrycollection zm( polygonzm((10 10 5 5.1,10 10 5 5.1, 10 10 5 5.1)), Point zm(10 10 5 5.1), linestringzm(10 10 5 5.1, 10 10 5 5.1), polygonzm((10 10 5 5.1,10 10 5 5.1, 10 10 5 5.1), (10 10 5 5.1,10 10 5 5.1, 10 10 5 5.1)))", "1,1003,1,13,1,1,17,2,1,25,1003,1,37,2003,1", "10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1"}, 
+            new Object[]{"geometrycollectionzm( polygonzm((10 10 5 5.1,10 10 5 5.1, 10 10 5 5.1)), Point zm(10 10 5 5.1), linestringzm(10 10 5 5.1, 10 10 5 5.1), polygonzm((10 10 5 5.1,10 10 5 5.1, 10 10 5 5.1), (10 10 5 5.1,10 10 5 5.1, 10 10 5 5.1)),multipointzm(10 10 5 5.1, 10 10 5 5.1))", "1,1003,1,13,1,1,17,2,1,25,1003,1,37,2003,1,49,1,1,53,1,1", "10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1,10.0,10.0,5.0,5.1"} 
+      };
+      
+   }
+   /**
+    * Tests exception on invalids wkt
+    * {@link OracleWktCoordiantesProcessor#process(String, List, List)}
+    * 
+    * @param wkt
+    *           invalid Well-Known Text
+    */
+   @Test(dataProvider = "getInvalidWktData", expectedExceptions = IllegalArgumentException.class)
+   public void testConvertToFunctionException(final String wkt) throws IOException{
+      OracleWktCoordiantesProcessor processor = new OracleWktCoordiantesProcessor();
+      List<String> elementInfoArray = new ArrayList<String>();
+      List<String> ordinateArray = new ArrayList<String>();
+      processor.process(wkt, elementInfoArray, ordinateArray);
+
+   } 
+   
+   @DataProvider
+   public Object[][] getInvalidWktData() {
+      return new Object[][] { 
+            new Object[] { "PONIT(1 1)" },
+            new Object[] { "POINT(1)" },
+            new Object[] { "POINT()" },
+            new Object[] { "Z POINT(1 1)" },
+            new Object[] { "POINTZ(1 1)" },
+            new Object[] { "POINTMZ(1 1 1 1)" },
+            new Object[] { "POINTZM(1 1)" },
+            new Object[] { "POINTZM(1 1 1)" },
+            new Object[] { "LINESTRINGs (1 1, 2 2)" },
+            new Object[] { "LINESTRING((1 1, 2 2))" },
+            new Object[] { "POLYgonm((1 1, 2 2))" },
+            new Object[] { "POLYgon((1 1, 2 2),())" },
+            new Object[] { "POLYgon((1 1, 2 2),)" },
+            new Object[] { "poligon(1 1, 2 2, 1 1)" },
+            new Object[] { "multypoligon((1 1, 2 2, 1 1),(1 1, 2 2, 1 1))" },
+            new Object[] { "GeometryCollection ( LINESTRINGm (1 1 1, 2 2 2 )" },
+            new Object[] { "GeometryCollection ( )" },
+            new Object[] { "GeometryCollectionz ( LINESTRING (1 1, 2 2 )" },
+      };
+
+   }
+
+}

--- a/src/test/java/liquibase/ext/spatial/sqlgenerator/WktConversionUtilsTest.java
+++ b/src/test/java/liquibase/ext/spatial/sqlgenerator/WktConversionUtilsTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 import liquibase.database.Database;
+import liquibase.ext.spatial.sqlgenerator.WktConversionUtils.EWKTInfo;
 
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -134,5 +135,102 @@ public class WktConversionUtilsTest {
             new Object[] { "test", database, generator, "test" },
             new Object[] { wkt, database, generator, wkt + ",null" },
             new Object[] { srid + ";" + wkt, database, generator, wkt + ",4326" }, };
+   }
+   
+   /**
+    * Test {@link WktConversionUtils#getWktInfo(String)}
+    * 
+    * @param wkt
+    * @param wktWithoutSRID
+    * @param isV1_1
+    * @param srid
+    * @param geometryType
+    * @param geometryBaseType
+    * @param mCoordinate
+    * @param zCoordinate
+    * @param isMulti
+    * @param isColleciton
+    * @param data
+    */
+   @Test(dataProvider = "getWktInfoData")
+   public void testGetWktInfo(final String wkt,final String wktWithoutSRID, final boolean isV1_1, final String srid, final String geometryType, final String geometryBaseType, final boolean mCoordinate, final boolean zCoordinate, final boolean isMulti, final boolean isColleciton, final String data) {
+      final EWKTInfo info = WktConversionUtils.getWktInfo(wkt);
+      assertEquals(info.getOriginalWkt(), wkt.trim());
+      assertEquals(info.getWktWithoutSRID(), wktWithoutSRID);
+      assertEquals(info.isV1_1(),isV1_1);
+      assertEquals(info.getSrid(), srid);
+      assertEquals(info.getGeometryType(), geometryType);
+      assertEquals(info.getGeometryBaseType(), geometryBaseType);
+      assertEquals(info.isMCoordinate(), mCoordinate);
+      assertEquals(info.isZCoordinate(), zCoordinate);
+      assertEquals(info.isMulti(), isMulti);
+      assertEquals(info.isCollection(), isColleciton);
+      assertEquals(info.getData(), data);
+   }
+   
+   @DataProvider
+   public Object[][] getWktInfoData() {
+      return new Object[][] { 
+            // Test Point
+            new Object[] {" Point(1 1)", "Point(1 1)", true, null, "POINT","POINT", false, false, false, false, "1 1" },
+            new Object[] {" POIntz(1 1 1)", "POIntz(1 1 1)", false, null, "POINTZ","POINT", false, true, false,false, "1 1 1" },
+            new Object[] {"  point zm(1 1 1 1)  ", "point zm(1 1 1 1)", false, null, "POINTZM","POINT", true, true,false,false, "1 1 1 1" },
+            new Object[] {"point m(1 1 1)", "point m(1 1 1)", false, null, "POINTM","POINT", true, false, false, false, "1 1 1" },
+            new Object[] {"Srid=4326;point(1 1)", "point(1 1)", false, "4326", "POINT","POINT", false, false, false, false, "1 1" },
+            new Object[] {" SRID=4326;POINTZ(1 1 1)", "POINTZ(1 1 1)", false, "4326", "POINTZ","POINT", false, true, false, false, "1 1 1" },
+            new Object[] {"MULTIPOINTM(1 1 1, 2 2 2)", "MULTIPOINTM(1 1 1, 2 2 2)", false, null, "MULTIPOINTM","POINT", true, false, true, false, "1 1 1, 2 2 2" },
+            
+            // Test LineString
+            new Object[] {" Linestring(1 1, 2 2)", "Linestring(1 1, 2 2)", true, null, "LINESTRING","LINESTRING", false, false, false, false, "1 1, 2 2" },
+            new Object[] {" LINEStringz(1 1 1, 2 2 2)", "LINEStringz(1 1 1, 2 2 2)", false, null, "LINESTRINGZ","LINESTRING", false, true, false,false, "1 1 1, 2 2 2" },
+            new Object[] {"  linestring zm(1 1 1 1, 2 2 2 2)  ", "linestring zm(1 1 1 1, 2 2 2 2)", false, null, "LINESTRINGZM","LINESTRING", true, true,false,false, "1 1 1 1, 2 2 2 2" },
+            new Object[] {"linestring m(1 1 1, 2 2 2)", "linestring m(1 1 1, 2 2 2)", false, null, "LINESTRINGM","LINESTRING", true, false, false, false, "1 1 1, 2 2 2" },
+            new Object[] {"Srid=4326;linestring(1 1, 2 2)", "linestring(1 1, 2 2)", false, "4326", "LINESTRING","LINESTRING", false, false, false, false, "1 1, 2 2" },
+            new Object[] {" SRID=4326;LINESTRINGZ(1 1 1, 2 2 2)", "LINESTRINGZ(1 1 1, 2 2 2)", false, "4326", "LINESTRINGZ","LINESTRING", false, true, false, false, "1 1 1, 2 2 2" },
+            new Object[] {"MULTILINESTRINGM((1 1 1, 2 2 2),(3 3 3, 4 4 4))", "MULTILINESTRINGM((1 1 1, 2 2 2),(3 3 3, 4 4 4))", false, null, "MULTILINESTRINGM","LINESTRING", true, false, true, false, "(1 1 1, 2 2 2),(3 3 3, 4 4 4)" }, 
+            
+            // Test Polygon
+            new Object[] {" Polygon((1 1, 2 2, 3 3, 4 4, 1 1),(1.5 1.5, 1.75 1.75, 1.5 1.5))", "Polygon((1 1, 2 2, 3 3, 4 4, 1 1),(1.5 1.5, 1.75 1.75, 1.5 1.5))", true, null, "POLYGON","POLYGON", false, false, false, false, "(1 1, 2 2, 3 3, 4 4, 1 1),(1.5 1.5, 1.75 1.75, 1.5 1.5)" },
+            new Object[] {" POLygonz((1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1))", "POLygonz((1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1))", false, null, "POLYGONZ","POLYGON", false, true, false,false, "(1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1)" },
+            new Object[] {"  polygon zm((1 1 1 1, 2 2 2 2, 3 3 3 3, 4 4 4 4))  ", "polygon zm((1 1 1 1, 2 2 2 2, 3 3 3 3, 4 4 4 4))", false, null, "POLYGONZM","POLYGON", true, true,false,false, "(1 1 1 1, 2 2 2 2, 3 3 3 3, 4 4 4 4)" },
+            new Object[] {"polygon m((1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1))", "polygon m((1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1))", false, null, "POLYGONM","POLYGON", true, false, false, false, "(1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1)" },
+            new Object[] {"Srid=4326;polygon((1 1, 2 2, 3 3, 4 4, 1 1))", "polygon((1 1, 2 2, 3 3, 4 4, 1 1))", false, "4326", "POLYGON","POLYGON", false, false, false, false, "(1 1, 2 2, 3 3, 4 4, 1 1)" },
+            new Object[] {" SRID=4326;POLYGONZ((1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1))", "POLYGONZ((1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1))", false, "4326", "POLYGONZ","POLYGON", false, true, false, false, "(1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1)" },
+            new Object[] {"MULTIPOLYGONM(((1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1)),((1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1), (1.5 1.5 1.5, 1.75 1.75 1.75, 1.5 1.5 1.5)))", "MULTIPOLYGONM(((1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1)),((1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1), (1.5 1.5 1.5, 1.75 1.75 1.75, 1.5 1.5 1.5)))", false, null, "MULTIPOLYGONM","POLYGON", true, false, true, false, "((1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1)),((1 1 1, 2 2 2, 3 3 3, 4 4 4, 1 1 1), (1.5 1.5 1.5, 1.75 1.75 1.75, 1.5 1.5 1.5))" }, 
+            
+            // Test Collection
+            new Object[] {"GeometryCollection (Point(1 1),POINT(2 2))", "GeometryCollection (Point(1 1),POINT(2 2))", true, null, "GEOMETRYCOLLECTION","GEOMETRYCOLLECTION", false, false, false, true, "Point(1 1),POINT(2 2)" },
+            new Object[] {"  GeometryCollectionZ (POIntz(1 1 1), POIntz(1 1 1)) ", "GeometryCollectionZ (POIntz(1 1 1), POIntz(1 1 1))", false, null, "GEOMETRYCOLLECTIONZ","GEOMETRYCOLLECTION", false, true, false,true, "POIntz(1 1 1), POIntz(1 1 1)" },
+            new Object[] {"  geometrycollection zm(pointzm(1 1 1 1),pointzm(1 1 1 1))  ", "geometrycollection zm(pointzm(1 1 1 1),pointzm(1 1 1 1))", false, null, "GEOMETRYCOLLECTIONZM","GEOMETRYCOLLECTION", true, true,false,true, "pointzm(1 1 1 1),pointzm(1 1 1 1)" },
+            new Object[] {"geometrycollection m (point m(1 1 1))", "geometrycollection m (point m(1 1 1))", false, null, "GEOMETRYCOLLECTIONM","GEOMETRYCOLLECTION", true, false, false, true, "point m(1 1 1)" },
+            new Object[] {"Srid=4326;geometrycollection(point(1 1))", "geometrycollection(point(1 1))", false, "4326", "GEOMETRYCOLLECTION","GEOMETRYCOLLECTION", false, false, false, true, "point(1 1)" },
+            new Object[] {" SRID=4326;POINTZ(1 1 1)", "POINTZ(1 1 1)", false, "4326", "POINTZ","POINT", false, true, false, false, "1 1 1" },
+       };
+      
+   }
+   
+   /**
+    * Tests exception on invalids wkt
+    * {@link WktConversionUtils#getWktInfo(String)}
+    * 
+    * @param wkt
+    *           invalid Well-Known Text
+    */
+   @Test(dataProvider = "getInvalidWktData", expectedExceptions = IllegalArgumentException.class)
+   public void testConvertToFunctionException(final String wkt) {
+      final EWKTInfo info = WktConversionUtils.getWktInfo(wkt);
+      fail("Info returned " + info);
+   }
+   
+   @DataProvider
+   public Object[][] getInvalidWktData() {
+      return new Object[][] { 
+            new Object[] { "PONIT(1 1)" },
+            new Object[] { "Z POINT(1 1)" },
+            new Object[] { "POINTMZ(1 1)" },
+            new Object[] { "POINTMZ 1 1)" },
+            new Object[] { "LINESTRINGs (1 1, 2 2)" },
+      };
+
    }
 }


### PR DESCRIPTION
Liquibase Spatial uses Oracle WKT support to insert goemtries,
but this is limmited as Oracle support OGC WKT v1.1, so
only 2D geometries are supported.

This PR add support to generate SDO_GEOMETRY expressions on native
constructor way to support 3D and 4D Geometries (3D,2DM,3DM).

Also improves the USER_SDO_GEOM_METADATA generation to handle correctly
dimensions for projected SRS and > 2D geometies on Spatial index
creation.

This PR includes some integration test.
