### PR TITLE
prevent null pointer exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /test-output
 /derby.log
 /pom.xml.bak
+.idea
+*.iml
+

--- a/src/main/java/liquibase/ext/spatial/sqlgenerator/AddGeometryColumnGeneratorGeoDB.java
+++ b/src/main/java/liquibase/ext/spatial/sqlgenerator/AddGeometryColumnGeneratorGeoDB.java
@@ -52,14 +52,16 @@ public class AddGeometryColumnGeneratorGeoDB extends
    public ValidationErrors validate(final AddColumnStatement statement,
          final Database database, final SqlGeneratorChain sqlGeneratorChain) {
       final ValidationErrors errors = new ValidationErrors();
-      final LiquibaseDataType dataType = DataTypeFactory.getInstance()
-            .fromDescription(statement.getColumnType(), database);
+      if (statement != null && statement.getColumnType() != null) {
+         final LiquibaseDataType dataType = DataTypeFactory.getInstance()
+                 .fromDescription(statement.getColumnType(), database);
 
-      // Ensure that the SRID parameter is provided.
-      if (dataType instanceof GeometryType) {
-         final GeometryType geometryType = (GeometryType) dataType;
-         if (geometryType.getSRID() == null) {
-            errors.addError("The SRID parameter is required on the geometry type");
+         // Ensure that the SRID parameter is provided.
+         if (dataType instanceof GeometryType) {
+            final GeometryType geometryType = (GeometryType) dataType;
+            if (geometryType.getSRID() == null) {
+               errors.addError("The SRID parameter is required on the geometry type");
+            }
          }
       }
       final ValidationErrors chainErrors = sqlGeneratorChain.validate(
@@ -75,10 +77,12 @@ public class AddGeometryColumnGeneratorGeoDB extends
          final Database database, final SqlGeneratorChain sqlGeneratorChain) {
 
       GeometryType geometryType = null;
-      final LiquibaseDataType dataType = DataTypeFactory.getInstance()
-            .fromDescription(statement.getColumnType(), database);
-      if (dataType instanceof GeometryType) {
-         geometryType = (GeometryType) dataType;
+      if (statement != null && statement.getColumnType() != null) {
+         final LiquibaseDataType dataType = DataTypeFactory.getInstance()
+                 .fromDescription(statement.getColumnType(), database);
+         if (dataType instanceof GeometryType) {
+            geometryType = (GeometryType) dataType;
+         }
       }
 
       final boolean isGeometryColumn = geometryType != null;


### PR DESCRIPTION
So I'm not sure if there's just something goofy with my setup, but by simply bringing this dependency, liquibase in spring boot would fail with null pointer exceptions because the `columnType` in these `AddColumnStatement`'s were `null`.