### PR TITLE
Update the function name to support MySql8 changes

### DIFF
--- a/src/main/java/liquibase/ext/spatial/sqlgenerator/SpatialInsertGeneratorMySQL.java
+++ b/src/main/java/liquibase/ext/spatial/sqlgenerator/SpatialInsertGeneratorMySQL.java
@@ -22,6 +22,6 @@ public class SpatialInsertGeneratorMySQL extends AbstractSpatialInsertGenerator 
     */
    @Override
    public String getGeomFromWktFunction() {
-      return "GeomFromText";
+      return "ST_GeomFromText";
    }
 }


### PR DESCRIPTION
In MySql8 GeomFromText is removed.

ST_GeomFromText works both in 5.7 & 8